### PR TITLE
move Zenodo jupyterLab doc to vre-hub main docs

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -22,9 +22,9 @@ env:
 jobs:
   # Single deploy job since we're just deploying
   build:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    # environment:
+    #   name: github-pages
+    #   url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,8 +1,6 @@
 name: Test build
 on:
   pull_request:
-    branches: 
-      - **
     paths-ignore:
       - 'README.md'
 

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -2,7 +2,7 @@ name: Test build
 on:
   pull_request:
     branches: 
-      - 'main'
+      - **
     paths-ignore:
       - 'README.md'
 

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -22,9 +22,6 @@ env:
 jobs:
   # Single deploy job since we're just deploying
   build:
-    # environment:
-    #   name: github-pages
-    #   url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs/extensions/zenodo-jupyterlab/extension-usage.md
+++ b/docs/extensions/zenodo-jupyterlab/extension-usage.md
@@ -22,7 +22,7 @@ This interface is meant to mimic the record entries on `zenodo.org`.
 Upon searching for a community, when clicked, the user will be able to search for specific records within that community, and a banner will display which community is being searched through above the results. Note: the community searching can be canceled by either pressing the `X` next to this community banner or searching for a new community.
 
 ### Potential Future Features
-Depending on the usefulness of the feature in terms of the scope of this extension, advanced search settings might be added in future updates. These would mimic those on <zenodo.org>: restrict file type, resource type, access level, ...
+Depending on the usefulness of the feature in terms of the scope of this extension, advanced search settings might be added in future updates. These would mimic those on `zenodo.org`: restrict file type, resource type, access level, ...
 
 
 ## ZenodoAPI interactions {#zenodoAPI}

--- a/docs/extensions/zenodo-jupyterlab/extension-usage.md
+++ b/docs/extensions/zenodo-jupyterlab/extension-usage.md
@@ -1,0 +1,48 @@
+# Frontend Usage Guide
+
+## Searching 
+
+The user has the ability to search both records and communities, which are collections of records. The actual search query ability is derived from [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html), just as the [Zenodo REST API](https://developers.zenodo.org/#rest-api) is.
+
+The results are returned in pages of 25 results, with the ability to navigate the pages of results. This leverages the built-in `page` and `size` parameters present in the Zenodo REST API, which appear as `kwargs` in `eOSSR`, the python library on which all backend communication with Zenodo is based.
+
+For searched records, the title, resource type, and date published are displayed in the table. For communities, only the title and date published are displayed. Both searches are returned and sorted by most recently updated.
+
+*Note*: As each page is a new API call, if records are added that match the search parameters in between page calls, there is a possibility for repeating records, as they are pushed to later pages. Though, given the probable specificity of users' searches, this should not be an issue.
+
+### Record Information
+When a record is selected, more record information is displayed:
+* Title of the record as a link to the Zenodo record entry on `zenodo.org`
+* Author List, with institutions available upon hovering
+* List of files as download links (WIP, currently install to local computer, but in future updates will install to the `$HOME` directory in the Jupyter instance)
+
+This interface is meant to mimic the record entries on `zenodo.org`.
+
+### Community Searching
+Upon searching for a community, when clicked, the user will be able to search for specific records within that community, and a banner will display which community is being searched through above the results. Note: the community searching can be canceled by either pressing the `X` next to this community banner or searching for a new community.
+
+### Potential Future Features
+Depending on the usefulness of the feature in terms of the scope of this extension, advanced search settings might be added in future updates. These would mimic those on <zenodo.org>: restrict file type, resource type, access level, ...
+
+
+## ZenodoAPI interactions {#zenodoAPI}
+This section involves all actions that interact with the `eossr.api.zenodo.ZenodoAPI` module, which creates a connection to Zenodo with an API access token for continued use.
+
+### Logging in
+The user is able to either log in to the main [Zenodo](zenodo.org) software or the [Sandbox Zenodo](sandbox.zenodo.org) software (for testing) using their Personl Access Token. This token is created in the Zenodo User Settings > Applications > Personal Access Tokens. When the user logs in, the validity of their token in the chosen software is determined via a query of that user's deposits. If the token is invalid, this is displayed clearly below the access token field.
+
+The entered access token and choice of whether or not to work within the main or sandbox software are saved as environmental variables within the Jupyter Session: `ZENODO_API_KEY` and `SANDBOX_ZENODO`, respectively. These variables will be accessible across the Jupyter Session, however they will not be reflected in any open terminals; new terminals/notebooks must be opened to reflect the change.
+
+### Uploading A Record
+The sandbox checkbox at the top of the Upload page is readonly and indicates whether of not the user logged in to the main software or the sandbox version. This is to inform the user of in which software their deposit will be made.
+
+In order to continue, the user had to fill in the necessary information:
+* Select at least one file to upload (the file browser initially shows the contents of the `$Home` directory in the Jupyter Session)
+* Title
+* Select a Resource Type
+* Include at least one Creator's name
+* Optional Information:
+** DOI (otherwise generated automatically)
+** Multiple Creators and include affiliations
+
+Once the `Next` button is selected, a confirmation page is shown with all of the entered information. When `Confirm` is pressed, a deposit is made and the appropriate metadata is assigned. ***Note***: As is currently stands, only the title is able to be set via this mechanism, and the file upload has yet to be implemented.

--- a/docs/extensions/zenodo-jupyterlab/extension-usage.md
+++ b/docs/extensions/zenodo-jupyterlab/extension-usage.md
@@ -29,7 +29,7 @@ Depending on the usefulness of the feature in terms of the scope of this extensi
 This section involves all actions that interact with the `eossr.api.zenodo.ZenodoAPI` module, which creates a connection to Zenodo with an API access token for continued use.
 
 ### Logging in
-The user is able to either log in to the main [Zenodo](zenodo.org) software or the [Sandbox Zenodo](sandbox.zenodo.org) software (for testing) using their Personl Access Token. This token is created in the Zenodo User Settings > Applications > Personal Access Tokens. When the user logs in, the validity of their token in the chosen software is determined via a query of that user's deposits. If the token is invalid, this is displayed clearly below the access token field.
+The user is able to either log in to the main [Zenodo](https://zenodo.org/) software or the [Sandbox Zenodo](https://sandbox.zenodo.org/) software (for testing) using their Personl Access Token. This token is created in the Zenodo User Settings > Applications > Personal Access Tokens. When the user logs in, the validity of their token in the chosen software is determined via a query of that user's deposits. If the token is invalid, this is displayed clearly below the access token field.
 
 The entered access token and choice of whether or not to work within the main or sandbox software are saved as environmental variables within the Jupyter Session: `ZENODO_API_KEY` and `SANDBOX_ZENODO`, respectively. These variables will be accessible across the Jupyter Session, however they will not be reflected in any open terminals; new terminals/notebooks must be opened to reflect the change.
 

--- a/docs/extensions/zenodo-jupyterlab/implementation/backend.md
+++ b/docs/extensions/zenodo-jupyterlab/implementation/backend.md
@@ -1,0 +1,164 @@
+# Backend Documentation
+
+## General Framework
+The backend for this extension is built as a Jupyter Server Extension. The project entry points are specified with the `pyproject.toml` file in the root directory. These point to the `zenodo_jupyterlab.server` module, which contains the `extenion.py` and `__init__.py` files which run the function that sets up the API handlers defined within other files in that directory. This guide will go through each section, with explanation of functionality.
+
+# Files in `zenodo_jupyterlab/server/`
+
+## `extension.py` 
+`_load_jupyter_server_extenion` is a basic function that calls on `setup_handlers` which is defined in `handlers.py` and passes the `server_app.web_app` object. This is automatically passed via the server extension points.
+
+## `__init__.py` 
+Defines the `_jupyter_server_extension_points` function that signals to the primary extension in `pyproject.toml` how to access the server extension and to build when it built.
+
+## `handlers.py` 
+This file generates the API endpoints for use by the frontend components. All handlers inherit from `jupyter_server.base.handlers.APIHandler` (except the XSRFTokenHandler inherits from JupyterHandler). For simplicity, parameters are placed within the function definitions here, though they are accessed via the `APIHandler.get_argument()` function because they are URI encoded in the API calls. In addition, return statements are defined plainly here, though they are actually returned via the `APIHandler.finish()` function.
+
+### `class EnvHandler`
+Interacts with environmental variables in the Jupyter instance. Exploits the `os` module.
+#### `get(env_var: string)`
+Simple function to return the value of a stored environmental variable. Returns a dict containing the variable name and value.
+> **Returns:** `{env_var: *value*}`
+
+#### `post(key: string, value: string)`
+Simple function to set the value of an environmental variable. Returns a dict with the parameters.
+> **Returns:** `{key, value}
+
+### `class XSRFTokenHandler`
+Note: this inherits from JupyterHandler, not APIHandler.
+
+#### `get(self: JupyterHandler)`
+Accesses JupyterHandler.xsrf_token and returns it.
+> **Returns:** {'xsrfToken': xsrf_token}
+
+### `class Search RecordHandler`
+Handler designed to interact with `searchRecords` function defined in [`search.py`](#search).
+
+#### `get(search_field: string, page: int, communities: string)`
+Awaits response from `searchRecords` after passing all of the arguments and returns the list of corresponding records (max size: 25).
+> **Returns:** {'records': *response*}
+
+### `class SearchCommunityHandler`
+Handler designed to interact with `searchCommunities` function defined in [`search.py`](#search).
+
+#### `get(search_field: string, page: int)`
+Awaits response from `searchCommunities` after passing all of the arguments and returns the list of corresponding communities (max size: 25).
+> **Returns:** {'communities': *response*}
+
+### `class RecordInfoHandler`
+Handler designed to interact with `recordInformation` function defined in [`search.py`](#search).
+
+#### `get(record-id: string)`
+Awaits response from `recordInformation` after passing the `record-id` and returns the desired data.
+> **Returns:** {'data': *response*}
+
+### `class FileBrowserHandler`
+Interacts with environmental information about the folder and files in the `$HOME` directory and child directories.
+
+#### `get(path: string)
+Pulls the Jupyter instance home directory from the `$HOME` environmental variable. Then appends the path passed to this to generate a relative path and verifies whether it exists (if not, returns an "error"). Exploits the `os.listdir` function to iterate through entries within the folder. Note: it explicitly ignores all entries that start with ".", though, in principle, these should be excluded by `listdir`. It then accumulates a list of directories of entry information:
+```
+entry = {
+    "name": file name,
+    "type": directory or file,
+    "path": relative path from home directory,
+    "modified": isoformatted timestamp of last modification,
+    "size": size
+}
+```
+This information is all drawn from the returned data from `os.listdir`.
+> **Returns:** {'entries': *list of entry dictionaries*}
+
+### `class ZenodoAPIHandler`
+Interacts with all functions that make calls to the `eossr.api.zenodo.ZenodoAPI` object. They are contained within this class to limit the need of generating new `ZenodoAPI` objects with each interaction.
+
+#### `property zAPI`
+Once logged in, this will hold a `ZenodoAPI` object initialized with the input access token and sandbox boolean. As long as they do not log in again, this object will remain for the lifetime of the Jupyter instance.
+
+#### `post(form_data: json dictionary)`
+Takes in a `form_data` JSON dictionary, that contains at least an `action` entry, which specifies which code to run.
+
+##### `if action == 'check-connection'`
+Verifies the validity of a Zenodo access token via the `checkZenodoConnection` function defined in [`testConnection.py`](#testConnection). If valid, sets `zAPI` to an initialized `ZenodoAPI` object. Returns the response from the called function.
+> **Returns:** {'status': *response*}
+
+##### `if action == 'upload'`
+Interacts with the `upload` function defined in `upload.py`. If `zAPI` is not yet initialized, the function returns a status of "Please log in before attempting to upload." Otherwise, returns the response from the function.
+> **Returns:** {'status': *response*}
+
+### `class ServerInfoHandler`
+
+#### `get`
+Retrieves the home directory.
+> **Returns:** {'root_dir': *home directory*}
+
+### `setup_handlers(web_app)`
+Defines the API endpoints for access from the frontend. Builds the urls off of the "web_app" base path and "zenodo-jupyterlab". Thus all handlers are of the form: base_path + "zenodo-jupyterlab-*action*". This function then adds these endpoints to the web_app.
+
+## `search.py` 
+This files handles all search requests to Zenodo via the [`eOSSR`](https://gitlab.com/escape-ossr/eossr) library.
+
+### `searchRecords(search_field: string, page: int, **kwargs)`
+Calls the `eossr.api.zenodo.search_records` with the given arguments, as well as restricts the size of the response to 25 (i.e. passes `size = 25` as well). Parses the returned list of `eossr.api.zenodo.Record` objects and returns a list of the following kinds of dictionaries:
+```
+record = {
+    "id": Record ID,
+    "title": Record title,
+    "date": Date Published,
+    "resource_type": Records resource type (from within the metadata)
+}
+```
+If this call to `eOSSR` fails, the function simply returns `["failed"]`.
+> **Returns:** [list of records]
+
+### `searchCommunities(search_field: string, page: int)`
+Calls the `eossr.api.zenodo.search_communities` with the given arguments, as well as restricts the size of the response to 25 (i.e. passes `size = 25` as well). Parses the returned list of dictionaries and returns a list of the following kinds of dictionaries:
+```
+community = {
+    "id": Community ID,
+    "title": Community title,
+    "date": Date Published,
+}
+```
+If this call to `eOSSR` fails, the function simply returns `["failed"]`.
+> **Returns:** [list of communities]
+
+### `recordInformation(recordID: string)`
+Returns more specific information about a specified record via `eossr.api.zenodo.get_record`. Parses the returned data from this function and creates the following dictionary:
+```
+record= {
+    'authors': authors with affiliations as listed in the record,
+    'filelist': the list of files (full download links) attached to record
+}
+```
+Note: The existing information such as title and id are still held on the frontend in the tabular display, so no need to repass that information. Secondary note: if this call fails, this function returns {"status": "failed"}
+    **Returns:** *record*
+
+## `testConnection.py` 
+File devoted to validating Zenodo access tokens.
+
+### `checkZenodoConnection`
+Extracts the access token and sandbox boolean from the environmental variables `ZENODO_API_KEY` and `ZENODO_SANDBOX`, respectively. Parses the string value of the sandbox boolean into a Python boolean (stored as a string due to the mismatch is syntax between Typescript and Python booleans). Creates a `eossr.api.zenodo.ZenodoAPI` object with those extracted variables as arguments and stores it in `zAPI`. Then, uses the `eossr.api.zenodo.ZenodoAPI.query_user_deposits` function and extracts the status from this response, which indicates whether or not the access token is valid or if a connection can be made to the Zenodo REST API. If either stage fails, `zAPI` is initialized to `None` and the query status is set to 0.
+> **Returns:** status code of the query, `zAPI`
+
+## `upload.py` 
+Devoted to generating and populating new Zenodo record deposits.
+
+### `createDeposit(zAPI: eossr.api.zenodo.ZenodoAPI)`
+Uses `eossr.api.zenodo.ZenodoAPI.create_new_deposit` to create an empty deposit. Note: whether or not this deposit exists on Zenodo or Zenodo Sandbox is entirely dependent on what option the user selected when logging in.
+> **Returns:** ID of the newly created record
+
+### `createMetadata(zAPI: eossr.api.zenodo.ZenodoAPI, recordID: int, form_data: FormData object)`
+*Work in Progress*\
+Extracts title from form_data and creates a JSON dict as follows:
+```
+json_metadata = {
+    "title": given title
+}
+```
+Uses `eossr.api.zenodo.ZenodoAPI.set_deposit_metadata` to take in the recordID and the JSON data and add this metadata to the existing Zenodo object.
+> **Returns:** *response*
+
+### `upload(zAPI: eossr.api.zenodo.ZenodoAPI, form_data: FormData object)`
+Verifies if zAPI has been initialized; if not, returns `None`. Calls `createDeposit` and passes `zAPI` and captures returns record ID. Then uses this record ID, form_data, and the `zAPI` to call `createMetadata`.
+> **Returns:** "Success" if *response* doesn't equal `None`

--- a/docs/extensions/zenodo-jupyterlab/implementation/backend.md
+++ b/docs/extensions/zenodo-jupyterlab/implementation/backend.md
@@ -22,42 +22,42 @@ Simple function to return the value of a stored environmental variable. Returns 
 
 #### `post(key: string, value: string)`
 Simple function to set the value of an environmental variable. Returns a dict with the parameters.
-> **Returns:** `{key, value}
+> **Returns:** `{key, value}`
 
 ### `class XSRFTokenHandler`
 Note: this inherits from JupyterHandler, not APIHandler.
 
 #### `get(self: JupyterHandler)`
 Accesses JupyterHandler.xsrf_token and returns it.
-> **Returns:** {'xsrfToken': xsrf_token}
+> **Returns:** `{'xsrfToken': xsrf_token}`
 
 ### `class Search RecordHandler`
 Handler designed to interact with `searchRecords` function defined in [`search.py`](#search).
 
 #### `get(search_field: string, page: int, communities: string)`
 Awaits response from `searchRecords` after passing all of the arguments and returns the list of corresponding records (max size: 25).
-> **Returns:** {'records': *response*}
+> **Returns:** `{'records': *response*}`
 
 ### `class SearchCommunityHandler`
 Handler designed to interact with `searchCommunities` function defined in [`search.py`](#search).
 
 #### `get(search_field: string, page: int)`
 Awaits response from `searchCommunities` after passing all of the arguments and returns the list of corresponding communities (max size: 25).
-> **Returns:** {'communities': *response*}
+> **Returns:** `{'communities': *response*}`
 
 ### `class RecordInfoHandler`
 Handler designed to interact with `recordInformation` function defined in [`search.py`](#search).
 
 #### `get(record-id: string)`
 Awaits response from `recordInformation` after passing the `record-id` and returns the desired data.
-> **Returns:** {'data': *response*}
+> **Returns:** `{'data': *response*}`
 
 ### `class FileBrowserHandler`
 Interacts with environmental information about the folder and files in the `$HOME` directory and child directories.
 
 #### `get(path: string)
 Pulls the Jupyter instance home directory from the `$HOME` environmental variable. Then appends the path passed to this to generate a relative path and verifies whether it exists (if not, returns an "error"). Exploits the `os.listdir` function to iterate through entries within the folder. Note: it explicitly ignores all entries that start with ".", though, in principle, these should be excluded by `listdir`. It then accumulates a list of directories of entry information:
-```
+```json
 entry = {
     "name": file name,
     "type": directory or file,
@@ -67,7 +67,7 @@ entry = {
 }
 ```
 This information is all drawn from the returned data from `os.listdir`.
-> **Returns:** {'entries': *list of entry dictionaries*}
+> **Returns:** `{'entries': *list of entry dictionaries*}`
 
 ### `class ZenodoAPIHandler`
 Interacts with all functions that make calls to the `eossr.api.zenodo.ZenodoAPI` object. They are contained within this class to limit the need of generating new `ZenodoAPI` objects with each interaction.
@@ -80,27 +80,31 @@ Takes in a `form_data` JSON dictionary, that contains at least an `action` entry
 
 ##### `if action == 'check-connection'`
 Verifies the validity of a Zenodo access token via the `checkZenodoConnection` function defined in [`testConnection.py`](#testConnection). If valid, sets `zAPI` to an initialized `ZenodoAPI` object. Returns the response from the called function.
-> **Returns:** {'status': *response*}
+> **Returns:** `{'status': *response*}`
 
 ##### `if action == 'upload'`
 Interacts with the `upload` function defined in `upload.py`. If `zAPI` is not yet initialized, the function returns a status of "Please log in before attempting to upload." Otherwise, returns the response from the function.
-> **Returns:** {'status': *response*}
+> **Returns:** `{'status': *response*}`
 
 ### `class ServerInfoHandler`
 
 #### `get`
 Retrieves the home directory.
-> **Returns:** {'root_dir': *home directory*}
+> **Returns:** `{'root_dir': *home directory*}`
 
-### `setup_handlers(web_app)`
+### `setup_handlers`
+`setup_handlers(web_app)`
+
 Defines the API endpoints for access from the frontend. Builds the urls off of the "web_app" base path and "zenodo-jupyterlab". Thus all handlers are of the form: base_path + "zenodo-jupyterlab-*action*". This function then adds these endpoints to the web_app.
 
 ## `search.py` 
 This files handles all search requests to Zenodo via the [`eOSSR`](https://gitlab.com/escape-ossr/eossr) library.
 
-### `searchRecords(search_field: string, page: int, **kwargs)`
+### `searchRecords`
+`searchRecords(search_field: string, page: int, **kwargs)`
+
 Calls the `eossr.api.zenodo.search_records` with the given arguments, as well as restricts the size of the response to 25 (i.e. passes `size = 25` as well). Parses the returned list of `eossr.api.zenodo.Record` objects and returns a list of the following kinds of dictionaries:
-```
+```json
 record = {
     "id": Record ID,
     "title": Record title,
@@ -111,9 +115,11 @@ record = {
 If this call to `eOSSR` fails, the function simply returns `["failed"]`.
 > **Returns:** [list of records]
 
-### `searchCommunities(search_field: string, page: int)`
+### `searchCommunities`
+`searchCommunities(search_field: string, page: int)`
+
 Calls the `eossr.api.zenodo.search_communities` with the given arguments, as well as restricts the size of the response to 25 (i.e. passes `size = 25` as well). Parses the returned list of dictionaries and returns a list of the following kinds of dictionaries:
-```
+```json
 community = {
     "id": Community ID,
     "title": Community title,
@@ -123,16 +129,18 @@ community = {
 If this call to `eOSSR` fails, the function simply returns `["failed"]`.
 > **Returns:** [list of communities]
 
-### `recordInformation(recordID: string)`
+### `recordInformation`
+`recordInformation(recordID: string)`
+
 Returns more specific information about a specified record via `eossr.api.zenodo.get_record`. Parses the returned data from this function and creates the following dictionary:
-```
+```json
 record= {
     'authors': authors with affiliations as listed in the record,
     'filelist': the list of files (full download links) attached to record
 }
 ```
-Note: The existing information such as title and id are still held on the frontend in the tabular display, so no need to repass that information. Secondary note: if this call fails, this function returns {"status": "failed"}
-    **Returns:** *record*
+Note: The existing information such as title and id are still held on the frontend in the tabular display, so no need to repass that information. Secondary note: if this call fails, this function returns `{"status": "failed"}`.
+> **Returns:** *record*
 
 ## `testConnection.py` 
 File devoted to validating Zenodo access tokens.
@@ -144,14 +152,18 @@ Extracts the access token and sandbox boolean from the environmental variables `
 ## `upload.py` 
 Devoted to generating and populating new Zenodo record deposits.
 
-### `createDeposit(zAPI: eossr.api.zenodo.ZenodoAPI)`
+### `createDeposit`
+`createDeposit(zAPI: eossr.api.zenodo.ZenodoAPI)`
+
 Uses `eossr.api.zenodo.ZenodoAPI.create_new_deposit` to create an empty deposit. Note: whether or not this deposit exists on Zenodo or Zenodo Sandbox is entirely dependent on what option the user selected when logging in.
 > **Returns:** ID of the newly created record
 
-### `createMetadata(zAPI: eossr.api.zenodo.ZenodoAPI, recordID: int, form_data: FormData object)`
+### `createMetadata`
+`createMetadata(zAPI: eossr.api.zenodo.ZenodoAPI, recordID: int, form_data: FormData object)`
+
 *Work in Progress*\
 Extracts title from form_data and creates a JSON dict as follows:
-```
+```json
 json_metadata = {
     "title": given title
 }
@@ -159,6 +171,8 @@ json_metadata = {
 Uses `eossr.api.zenodo.ZenodoAPI.set_deposit_metadata` to take in the recordID and the JSON data and add this metadata to the existing Zenodo object.
 > **Returns:** *response*
 
-### `upload(zAPI: eossr.api.zenodo.ZenodoAPI, form_data: FormData object)`
+### `upload`
+`upload(zAPI: eossr.api.zenodo.ZenodoAPI, form_data: FormData object)`
+
 Verifies if zAPI has been initialized; if not, returns `None`. Calls `createDeposit` and passes `zAPI` and captures returns record ID. Then uses this record ID, form_data, and the `zAPI` to call `createMetadata`.
 > **Returns:** "Success" if *response* doesn't equal `None`

--- a/docs/extensions/zenodo-jupyterlab/implementation/frontend.md
+++ b/docs/extensions/zenodo-jupyterlab/implementation/frontend.md
@@ -8,7 +8,9 @@ The building of the of the frontend JupyterLab extension is handled entirely wit
 ## `index.tsx` 
 This file creates the entire frontend extension as a widget and adds it to the running Jupyter Lab session.
 
-### `class ZenodoWidget extends @lumino/widgets/Widget`
+### `class ZenodoWidget` 
+Extends `@lumino/widgets/Widget`. 
+
 This houses the entire extension. Given the nature of `@lumino/widgets/Widget`, this component is defined without `React`, though the `SideBarPanel` which is a sub-component that contains the all of the content of the widget is developed with `React` as are all futher sub-components.
 
 #### `constructor(app: @jupyterlab/application/JupyterFrontEnd)`
@@ -31,7 +33,9 @@ Unmounts the `root` component.
 #### `render`
 Simply runs the root objects `.render` function, passing the imported `SideBarPanel` component with the `app` and booleans passed to that component. This serves to render the whole widget on command to reflect changes. Note: This is necessary because the `ZenodoWidget` class is an extension of the `Widget` class and is by definition not a `React` component, thus `useEffect()` cannot be used.
 
-### `activate(app: JupyterFrontEnd, palette: ICommandPalette, restorer: ILayoutRestorer | null)`
+### `activate`
+`activate(app: JupyterFrontEnd, palette: ICommandPalette, restorer: ILayoutRestorer | null)`
+
 Function that defines how the widget is initialized and defines the app commands relating to the widget.
 
 Commands added to the hosted Jupyter instance:
@@ -45,76 +49,82 @@ Commands added to the hosted Jupyter instance:
 
 Finally, the function executes the "zenodo:open" command.
 
-### `plugin: JupyterFrontEndPlugin`
+### `plugin`
+`plugin: JupyterFrontEndPlugin`
+
 Defines the plugin in which the widget is housed and attaches the `activate` function defined above. Requires `@jupyterlab/apputils/ICommandPalette` and includes optional package `@jupyterlab/application/ILayoutRestorer`. This plugin is exported as the extension.
 
-## `API/API_functions.tsx` 
+## API
+
+### `API_functions.tsx` 
 This file defines the functions that access the API endpoints set up in the backend. It does so via the `requestAPI` function defined in `handlers.tsx` below.
 
-### `getEnvVariable(varName: string)`
+#### `getEnvVariable(varName: string)`
 Makes a GET request to the `zenodo-jupyterlab/env` API endpoint with the encoded argument `env_var` and the value passed in the function call. Returns the response from the API endpoint.
 > **Returns:** *data* or `console.error` message
 
-### `setEnvVariable(key: string, value: string)`
+#### `setEnvVariable(key: string, value: string)`
 Makes a POST request to the `zenodo-jupyterlab/env` API endpoint with a stringified JSON object containing the key and value passed to the function. Returns nothing or `console.error` message.
 
-### `testZenodoConnection`
+#### `testZenodoConnection`
 Makes a POST request to the `zenodo-jupyterlab/zenodo-api` API endpoint with a stringified JSON object: `{action: "check-connection"}`. This action component relays which `ZenodoAPI` action to take in the endpoint, which contains both logic for checking the connection and for uploading a deposit. Returns the response from the endpoint.
 > **Returns:** *data* or `console.error` message
 
-### `depositUpload(payload: UploadPayload)`
+#### `depositUpload(payload: UploadPayload)`
 Note: The UploadPayload type is simply a JSON dictionary with specified keys, imported rather than defined here for simplicity; its definition is housed in `/src/components/type.tsx`. \
 Makes a POST request to the `zenodo-jupyterlab/zenodo-api` API endpoint with a stringified JSON object containing `payload`. Returns the response from the endpoint.
 > **Returns:** *data* or `console.error` message
 
-### `searchRecords(search_field: string, page: number, kwargs: Record<string, any> = {})`
+#### `searchRecords(search_field: string, page: number, kwargs: Record<string, any> = {})`
 Note: The kwargs argument takes in a `Record` string, which is simply a flexible definition of a dictionary with the stated variable types for keys and values.\
 Generates the URI encoded URL for the API endpoint by first appending `string_field` and `page` and then iterating through kwargs. Makes a GET request to `zenodo-jupyterlab/search-records` with these encoded arguments. Returns the response from the endpoint.
 > **Returns:** *data* or `console.error` message
 
-### `searchCommunities(search_field: string, page: number)`
+#### `searchCommunities(search_field: string, page: number)`
 Makes a GET request to the 'zenodo-jupyterlab/search-communities` endpoint with `search_field` and `page` encoded. Returns the response from the endpoint.
 > **Returns:** *data* or `console.error` message
 
-### `recordInformation(recordID: number)`
+#### `recordInformation(recordID: number)`
 Makes a GET request to the `zenodo-jupyterlab/record-information` API endpoint with `recordID` encoded. Returns the response from the endpoint.
 > **Returns:** *data* or `console.error` message
 
-### `getServerRootDir`
+#### `getServerRootDir`
 Makes a GET request to the `zenodo-jupyterlab/server-info` API endpoint. Returns the response from the endpoint.
 > **Returns:** *data* or `console.error` message
 
-### `fetchSandboxStatus`
+#### `fetchSandboxStatus`
 Makes a FETCH request to `zenodo-jupyterlab/env` API endpoint with `env_var` as `ZENODO_SANDBOX`.
 > **Returns:** *value* or `console.error` message
 
-## `API/handlers.tsx` 
+### `handlers.tsx` 
 This file defines a function for making API requests.
 
-### `class NetworkError extends Error`
+#### `class NetworkError extends Error`
 Build errors completely identically to `Error`, but tags them as Network Errors (i.e. connection issues to backend API).
 
-### `class ResponseError extends Error`
+#### `class ResponseError extends Error`
 Build errors completely identically to `Error`, but tags them as Response Errors (i.e. issues in the backend API).
 
-### `requestAPI(endPoint: string, init: RequestInit)`
+#### `requestAPI(endPoint: string, init: RequestInit)`
 Pulls the settings from the `@jupyterlab/services/ServerConnection.makeSettings()` to build the full request URL from the `settings.baseURL` and `endPoint`. Retrieves the CSRF token from the `getCsrfToken` function defined below, which is then passed as a header on the request to bypass authentication issues. Returns the response from the API endpoint or an error.
 > **Returns:** *data* or `NetworkError` or `ResponseError`
 
-### `getCsrfToken`
+#### `getCsrfToken`
 Makes a FETCH request to the `zenodo-jupyterlab/xsrf_token` API endpoint, and returns the response.
 > **Returns:** *xsrfToken* or Error
 
-## `components/FileBrowser.tsx` 
+## Components
+
+### `FileBrowser.tsx` 
 Contains the component that displays the file browser in the Upload tab of the extension. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
 
-### `interface FileBrowserProps`
+#### `interface FileBrowserProps`
 Defines a parameter of `onSelectFile` of type `OnSelectFile`, which is a customized function type that takes in a string and returns nothing, imported from `components/type.tsx`. This is created to pass the `OnSelectFile` function defined in `components/upload.tsx` to the file browser.
 
-### `const FileBrowser: React.FC<FileBrowserProps>`
+#### `const FileBrowser: React.FC<FileBrowserProps>`
 File browser component
 
-#### `useState` Properties
+##### `useState` Properties
 ```
     const [entries, setEntries] = useState<FileEntry[]>([]);
     const [currentPath, setCurrentPath] = useState<string>('');
@@ -125,55 +135,55 @@ File browser component
     const [selectAll, setSelectAll] = useState<boolean>(false);
 ```
 
-#### `useEffect`
+##### `useEffect`
 Defines `fetchRootPath`, which sets `loading` to true and awaits `getServerRootDir`, defined in `API/API_functions`. Sets `rootPath` and `currentPath` to the returned path. Throws an error if any process fails.
 
-#### `useEffect`
+##### `useEffect`
 Defines `loadFiles` function, which makes a FETCH request to the `zenodo-jupyterlab/files` API endpoint with `currentPath` encoded. Sets `entries` to the list of entries returned from the API endpoint. Calls `loadFiles` upon changes to `currentPath`.
 
-#### `handleClick(entry: FileEntry)`
+##### `handleClick(entry: FileEntry)`
 Note: `FileEntry` is a specialized dictionary defined in `components/type.tsx`.\
 If the selected entry was a directory, this function sets `currentPath` to the path of that entry.
 
-#### `handleBreadcrumbClick(path: string)`
+##### `handleBreadcrumbClick(path: string)`
 When a breadcrumb (shortbut path links displayed when in nested directories) is clicked, simply sets `currentPath` to that breadcrumb's path.
 
-#### `breadcrumbs = useMemo()`
+##### `breadcrumbs = useMemo()`
 Executes on changes to `currentPath` or `rootPath`. Normalized the syntax of the paths, then iterate through each section of `currentPath` after `rootPath`. During this iteration, builds a list of `React.Fragments` which house the breadcrumbs for each nested directory, complete with click logic (`handleBreadcrumbClick`).
 > **Returns:** `breadcrumbItems: list`
 
-#### `handleSelectChange(path: string, isChecked: boolean)`
+##### `handleSelectChange(path: string, isChecked: boolean)`
 Compiles a list of all currently checked files within the browser, held in `selectedEntries`. This function also handles unchecking and removing of entries from this list. Also includes logic that toggles the "Select All" checkbox if the number of entries selected equals the length of the list.
 > **Returns:** `newEntries`
 
-#### `handleSelectFiles`
+##### `handleSelectFiles`
 Iterates through `selectedEntries` and applies the argument function `onSelectFile` to each's full path. Then sets `selectedEntries` to an empty Set.
 
-#### **Returns**
+##### **Returns**
 Returns the Filebrowser component, comprised of the breadcrumbs, the "Select All" checkbox, the list of files in the current directory (with a folder or file icon, title, size, and date modified), and a "Select" button, which triggers `handleSelectFiles`.
 
-## `components/NavBar.tsx` 
+### `NavBar.tsx` 
 Component that houses the navigation bar, below the Zenodo title icon in the widget. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
 
-### `interface NavBarProps`
+#### `interface NavBarProps`
 Defines an `app` parameter of type `@jupyterlab/application/JupyterFrontEnd`. This done is order to use the commands defined in `index.tsx`.
 
-### `NavBar: React.FC<NavBarProps>`
+#### `NavBar: React.FC<NavBarProps>`
 The navigation bar component.
 
-#### Click Handlers
+##### Click Handlers
 All click handlers simply trigger the `app` command corresponding to that button's title. For instance, pressing the "Search" button trigger the `zenodo-jupyterlab: search` command.
 
-#### **Returns**
+##### **Returns**
 Returns the NavBar component, complete with 3 buttons corresponding to the 3 panels available in the widget: "Login", "Search", and "Upload".
 
-## `components/SearchPanel.tsx` 
+### `SearchPanel.tsx` 
 This file houses the `SearchWidget` component, which contains all of the search logic and displays the results. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
 
-### `SearchWidget: React.FC`
+#### `SearchWidget: React.FC`
 Component housing all of the search related features.
 
-#### `useState` Properties
+##### `useState` Properties
 ```
     const [results, setResults] = useState<any[]>([]);
     const [searchTerm, setSearchTerm] = useState('');
@@ -191,19 +201,19 @@ Component housing all of the search related features.
     const [triggerSearch, setTriggerSearch] = useState(false);
 ```
 
-#### `useEffect`
+##### `useEffect`
 Upon changes in `triggerSearch` or `selectedCommunityID`, this runs `handleSearch`, passing the `resultsPage`, `selectedType`, and a dictionary of the form `{"communities": selectedCommunityID}` as arguments. Then sets `triggerSearch` to `false`.
 
-#### `handleSearch(page: number, type: string, kwrgs: Record<string, any> = {})`
+##### `handleSearch(page: number, type: string, kwrgs: Record<string, any> = {})`
 This function calls `searchRecords` or `searchCommunities`, both imported from `API/API_functions`, depending on `type`. Then, sets `results` to the returned data. Sets `lastSearchedType` to `type`, as well.
 
-#### `handleCheckboxChange(type: string)`
+##### `handleCheckboxChange(type: string)`
 Sets `selectedType` to whichever checkbox was selected.
 
-#### `handleRecordRowClick(recordID: number)`
+##### `handleRecordRowClick(recordID: number)`
 If the selected record is already selected, `selectedRecordID` is set to `null` and `recordInfo` is set to an empty dictionary. Otherwise, the function makes a call to `recordInformation`, imported from `API/API_functions.tsx` and sets `recordInfo` to what is returned.
 
-#### `handleCommunityClick(communityID: string, communityTitle: string)`
+##### `handleCommunityClick(communityID: string, communityTitle: string)`
 Runs the following:
 ```
     setSelectedCommunityTitle(communityTitle);
@@ -214,27 +224,27 @@ Runs the following:
     setTriggerSearch(true);
 ```
 
-#### `handleNextPageClick`
+##### `handleNextPageClick`
 Increments `resultsPage` and sets `triggerSearch` to true. If the `results` is not greater than 0, then it also sets `endPage` to true.
 
-#### `handleLastPageClick`
+##### `handleLastPageClick`
 Sets `endPage` to false, then decrements `resultsPage`, and triggers the search.
 
-#### `handleSearchClick`
+##### `handleSearchClick`
 Sets `endPage` to false, sets `resultsPage` to 1, and triggers the search.
 
-#### `handleClearCommunity`
+##### `handleClearCommunity`
 Sets selected community related parameters to `null`, sets `resultsPage` to 1, and triggers the search.
 
-#### `getFileNameFromUrl(url: string)`
+##### `getFileNameFromUrl(url: string)`
 Parses the passed url into a `URL` object. Strips "/content" from the paths. Then returns the last segment of the url.
 > **Returns:** *fileName*
 
-#### `cleanrUrl(url: string)`
+##### `cleanrUrl(url: string)`
 Converts the link attached to the record to a usable download link by stripping the "/content" off of the end and removing "/api" from the path as well.
 > **Returns:** *url*
 
-#### **Returns**
+##### **Returns**
 Always renders a search bar, checkboxes for "records" or "communities" and a "Search" button. The rest is rendered conditionally:
 * If `hasSearched` and `selectedType` is records, it displays a list of the returned records, specifically their title, date published, and resource type.
 > * If a record has been selected, it displays that record's extra information.
@@ -244,25 +254,25 @@ Always renders a search bar, checkboxes for "records" or "communities" and a "Se
 
 The Next and Last page buttons are displayed below the results.
 
-## `components/SideBarPanel.tsx` 
+### `SideBarPanel.tsx` 
 This is the main component of the extension. This houses every single element. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
 
-### `interface SideBarProps`
+#### `interface SideBarProps`
 * `app: JupyterFrontEnd`
 * `showLogin: boolean`
 * `showSearch: boolean`
 * `showUpload: boolean`
 
-### `SideBarPanel: React.FC<SideBarProps>`
+#### `SideBarPanel: React.FC<SideBarProps>`
 Contains all rendered content of the extension.
 
-#### **Returns**
+##### **Returns**
 Returns the Zenodo Title logo (`icons/ZenodoBlueTitle`) and the `NavBar` component, with the `app` passed as an argument. Conditionally renders either `Login`, `SearchWdiget`, or `Upload` depending on the values of the interface props.
 
-## `components/confirmation.tsx` 
+### `confirmation.tsx` 
 File containing the confirmation page component of the upload component. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
 
-### `interface` (Defined in line with component)
+#### `interface` (Defined in line with component)
 * `title: string`
 * `resourceType: string`
 * `creators: { name: string; affiliation: string }[]`
@@ -273,10 +283,10 @@ File containing the confirmation page component of the upload component. Note: a
 * `onEdit: () => void`
 * `onConfirm: () => void`
 
-### `Confirmation: React.FC<Props>`
+#### `Confirmation: React.FC<Props>`
 Component that is comprised of the users inputted information into the upload page along with a "Confirm" and "Edit" button.
 
-#### **Returns**
+##### **Returns**
 Returns a panel with all of the users inputted information for the record in the upload page, before pressing "Next".
 
 Note:
@@ -285,13 +295,13 @@ Note:
 * The confirmation displays whether or not the deposit is being made to Zenodo or Zenodo Sandbox.
 * The functions triggered by "Edit" and "Confirm" are passed as arguments to this component when rendered in `components/upload.tsx`.
 
-## `components/login.tsx` 
+### `login.tsx` 
 This file contains the logic and design for the `Login` component of the extension. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
 
-### `Login: React.FC`
+#### `Login: React.FC`
 Component housing the login interface of the extension.
 
-#### `useState` Properties
+##### `useState` Properties
 ```
     const [APIKey, setAPIKey] = useState('');
     const [outputData, setOutputData] = useState<string | null>(null);
@@ -300,25 +310,25 @@ Component housing the login interface of the extension.
     const [isSandbox, setIsSandbox] = useState(false);
 ```
 
-#### `handleLogin: useCallback`
+##### `handleLogin: useCallback`
 Function that relies on the setting of `APIKey` and `isSandbox`. Firstly, passes `isSandbox` to the `setEnvVariable` function from `API/API_functions.tsx`, which sets the env var `ZENODO_SANDBOX`. Then, the function uses `setEnvVariable` and `getEnvVariable` and verifies whether or not a key was given in the field. If not, it checks if there is one stored. If yes, then it stores the new key in the environment. Then, it executes `testAPIConnection`, which is defined below.
 
-#### `handleCheckboxChange(event: React.ChangeEvent<HTMLInputElement>)`
+##### `handleCheckboxChange(event: React.ChangeEvent<HTMLInputElement>)`
 Sets `isSandbox` corresponding to the state of the checkbox.
 
-#### `testAPIConnection`
+##### `testAPIConnection`
 Executes `testZenodoConnection` from `API/API_functions.tsx`. Based on the response, sets `connectionStatus` to either a success or failure message.
 
-#### **Returns**
+##### **Returns**
 Returns a field for entering the Zenodo access token, a checkbox indicating whether the user wishes to log in to the standard or sandbox platform, and a "Login" button. Conditionally renders messages indicating the success of storing variables in the environment and the validity of the access token in the chosen platform.
 
-## `components/Upload.tsx` {#upload}
+### `Upload.tsx` {#upload}
 File containing all of the styling and logic for the `Upload` tab of the extension. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
 
-### `Upload: React.FC`
+#### `Upload: React.FC`
 Component containing all of the upload-related content.
 
-#### `useState` Properties
+##### `useState` Properties
 ```
     const [title, setTitle] = useState('');
     const [resourceType, setResourceType] = useState('');
@@ -333,46 +343,46 @@ Component containing all of the upload-related content.
     const [expandedFile, setExpandedFile] = useState<string | null>(null);
 ```
 
-#### `useEffect`
+##### `useEffect`
 Defines a `fetchSandboxStatus` function that makes a FETCH request to `zenodo-jupyterlab/env` with the encoded `env_var=ZENODO_SANDBOX`. Sets `isSandbox` depending on the returned value. This function is executed on loading on the component.
 
-#### `handleFileClick(filePath: string)`
+##### `handleFileClick(filePath: string)`
 Sets `expandedFile` to either `null` or the new `filePath`, depending on whether or not the same was selected that was already expanded.
 
-#### `handleFileRemove(filePath: string)`
+##### `handleFileRemove(filePath: string)`
 Sets `selectedFilePaths` to the same list excluding the current `filePath`.
 
-#### `handleFileSelect(filePath: string)`
+##### `handleFileSelect(filePath: string)`
 Appends the selected `filePath` to the existing `selectedFilePaths`.
 
-#### `handleTitleChange(event: React.ChangeEvent<HTMLInputElement>)`
+##### `handleTitleChange(event: React.ChangeEvent<HTMLInputElement>)`
 Sets `title` to the form data.
 
-#### `handleResourceTypeChange(event: React.ChangeEvent<HTMLInputElement>)`
+##### `handleResourceTypeChange(event: React.ChangeEvent<HTMLInputElement>)`
 Sets `resourceType` to the form data.
 
-#### `handleDoiChange(event: React.ChangeEvent<HTMLInputElement>)`
+##### `handleDoiChange(event: React.ChangeEvent<HTMLInputElement>)`
 Sets `doi` to the form data.
 
-#### `handleCreatorChange(index: number, key: 'name' | 'affiliation', value: string)`
+##### `handleCreatorChange(index: number, key: 'name' | 'affiliation', value: string)`
 Creates a new Set based on `creators`, then changes the value of an entry based on `index` and `key`. Then, sets this new Set to `creators`.
 
-#### `addCreators`
+##### `addCreators`
 Appends a blank creator to the end of `creators`.
 
-#### `handleSubmit`
+##### `handleSubmit`
 Verifies whether or not all required information has been input; if not, generates an error message at the top of the page and exits the function. Otherwise, sets `confirmationVisible` to true.
 
-#### `handleEdit`
+##### `handleEdit`
 This function hides the confirmation page (passed through to the `Confirmation` component).
 
-#### `handleConfirm`
+##### `handleConfirm`
 Generates a `FormData` object with the input data. Defines an `UploadPayload` object (specific dictionary defined in `components/type.tsx`). Calls `depositUpload`, defined in `API/API_functions`, and passes `payload`.
 
-#### `fileName(filePath: string)`
+##### `fileName(filePath: string)`
 > **Returns:** Last segment of `filePath`
 
-#### **Returns**
+##### **Returns**
 If `confirmationVisible`, renders the `Confirmation` component with the following passed as arguments:
 ```
     title={title} 

--- a/docs/extensions/zenodo-jupyterlab/implementation/frontend.md
+++ b/docs/extensions/zenodo-jupyterlab/implementation/frontend.md
@@ -1,0 +1,389 @@
+# Frontend Documentation
+
+## General Framework 
+The building of the of the frontend JupyterLab extension is handled entirely within `pyproject.toml` in the root directory, which was originally generated from the `copier` template. All of the frontend components were originally generated with `copier` template of a JupyterLab extension: [template](https://github.com/jupyterlab/extension-template). This extension is built with NodeJS >= 20 with node dependencies contained within `yarn.lock`.
+
+# Files in `src/` 
+
+## `index.tsx` 
+This file creates the entire frontend extension as a widget and adds it to the running Jupyter Lab session.
+
+### `class ZenodoWidget extends @lumino/widgets/Widget`
+This houses the entire extension. Given the nature of `@lumino/widgets/Widget`, this component is defined without `React`, though the `SideBarPanel` which is a sub-component that contains the all of the content of the widget is developed with `React` as are all futher sub-components.
+
+#### `constructor(app: @jupyterlab/application/JupyterFrontEnd)`
+Extends the super type's constructor, as well as defines the app associated with the widget as the passed app (notably, the one that is active). Three properties are also defined and initialized that describe which section (Login, Search, or Upload) are showing when the extension is initially loaded. Basic widget styling is added as well from the `/style/base.css` file, and an icon is added to the sidebar, imported as an svg string and interpreted as a `@jupyterlab/ui-components/LabIcon` object.
+
+#### Properties
+* `private root: react-dom/client/Root`
+* `private app: JupyterFrontEnd`
+* booleans mentioned in constructor
+
+#### `onAfterAttach`
+Creates the `root` component from the inherited `Widget.node` object. Also calls the `render` function defined below.
+
+#### `onBeforeDetach`
+Unmounts the `root` component.
+
+#### Toggle functions
+`toggleLogin`, `toggleUpload`, and `toggleSearch` control the state of the booleans mentioned in the constructor that define which component is visible within the `SideBarPanel` component. Once these have been toggled, the whole component is re-rendered.
+
+#### `render`
+Simply runs the root objects `.render` function, passing the imported `SideBarPanel` component with the `app` and booleans passed to that component. This serves to render the whole widget on command to reflect changes. Note: This is necessary because the `ZenodoWidget` class is an extension of the `Widget` class and is by definition not a `React` component, thus `useEffect()` cannot be used.
+
+### `activate(app: JupyterFrontEnd, palette: ICommandPalette, restorer: ILayoutRestorer | null)`
+Function that defines how the widget is initialized and defines the app commands relating to the widget.
+
+Commands added to the hosted Jupyter instance:
+* "zenodo-jupyterlab: search": Toggles the search field
+* "zenodo-jupyterlab: login": Toggles the login field
+* "zenodo-jupyterlab: upload": Toggles the upload field
+* "zenodo: open":
+> * Creates new widget if widget is disposed
+> * Defines widget tracker via `@jupyterlab/apputils/WidgetTracker`
+> * Attaches widget to the Jupyter Lab Shell on the sidebar
+
+Finally, the function executes the "zenodo:open" command.
+
+### `plugin: JupyterFrontEndPlugin`
+Defines the plugin in which the widget is housed and attaches the `activate` function defined above. Requires `@jupyterlab/apputils/ICommandPalette` and includes optional package `@jupyterlab/application/ILayoutRestorer`. This plugin is exported as the extension.
+
+## `API/API_functions.tsx` 
+This file defines the functions that access the API endpoints set up in the backend. It does so via the `requestAPI` function defined in `handlers.tsx` below.
+
+### `getEnvVariable(varName: string)`
+Makes a GET request to the `zenodo-jupyterlab/env` API endpoint with the encoded argument `env_var` and the value passed in the function call. Returns the response from the API endpoint.
+> **Returns:** *data* or `console.error` message
+
+### `setEnvVariable(key: string, value: string)`
+Makes a POST request to the `zenodo-jupyterlab/env` API endpoint with a stringified JSON object containing the key and value passed to the function. Returns nothing or `console.error` message.
+
+### `testZenodoConnection`
+Makes a POST request to the `zenodo-jupyterlab/zenodo-api` API endpoint with a stringified JSON object: `{action: "check-connection"}`. This action component relays which `ZenodoAPI` action to take in the endpoint, which contains both logic for checking the connection and for uploading a deposit. Returns the response from the endpoint.
+> **Returns:** *data* or `console.error` message
+
+### `depositUpload(payload: UploadPayload)`
+Note: The UploadPayload type is simply a JSON dictionary with specified keys, imported rather than defined here for simplicity; its definition is housed in `/src/components/type.tsx`. \
+Makes a POST request to the `zenodo-jupyterlab/zenodo-api` API endpoint with a stringified JSON object containing `payload`. Returns the response from the endpoint.
+> **Returns:** *data* or `console.error` message
+
+### `searchRecords(search_field: string, page: number, kwargs: Record<string, any> = {})`
+Note: The kwargs argument takes in a `Record` string, which is simply a flexible definition of a dictionary with the stated variable types for keys and values.\
+Generates the URI encoded URL for the API endpoint by first appending `string_field` and `page` and then iterating through kwargs. Makes a GET request to `zenodo-jupyterlab/search-records` with these encoded arguments. Returns the response from the endpoint.
+> **Returns:** *data* or `console.error` message
+
+### `searchCommunities(search_field: string, page: number)`
+Makes a GET request to the 'zenodo-jupyterlab/search-communities` endpoint with `search_field` and `page` encoded. Returns the response from the endpoint.
+> **Returns:** *data* or `console.error` message
+
+### `recordInformation(recordID: number)`
+Makes a GET request to the `zenodo-jupyterlab/record-information` API endpoint with `recordID` encoded. Returns the response from the endpoint.
+> **Returns:** *data* or `console.error` message
+
+### `getServerRootDir`
+Makes a GET request to the `zenodo-jupyterlab/server-info` API endpoint. Returns the response from the endpoint.
+> **Returns:** *data* or `console.error` message
+
+### `fetchSandboxStatus`
+Makes a FETCH request to `zenodo-jupyterlab/env` API endpoint with `env_var` as `ZENODO_SANDBOX`.
+> **Returns:** *value* or `console.error` message
+
+## `API/handlers.tsx` 
+This file defines a function for making API requests.
+
+### `class NetworkError extends Error`
+Build errors completely identically to `Error`, but tags them as Network Errors (i.e. connection issues to backend API).
+
+### `class ResponseError extends Error`
+Build errors completely identically to `Error`, but tags them as Response Errors (i.e. issues in the backend API).
+
+### `requestAPI(endPoint: string, init: RequestInit)`
+Pulls the settings from the `@jupyterlab/services/ServerConnection.makeSettings()` to build the full request URL from the `settings.baseURL` and `endPoint`. Retrieves the CSRF token from the `getCsrfToken` function defined below, which is then passed as a header on the request to bypass authentication issues. Returns the response from the API endpoint or an error.
+> **Returns:** *data* or `NetworkError` or `ResponseError`
+
+### `getCsrfToken`
+Makes a FETCH request to the `zenodo-jupyterlab/xsrf_token` API endpoint, and returns the response.
+> **Returns:** *xsrfToken* or Error
+
+## `components/FileBrowser.tsx` 
+Contains the component that displays the file browser in the Upload tab of the extension. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
+
+### `interface FileBrowserProps`
+Defines a parameter of `onSelectFile` of type `OnSelectFile`, which is a customized function type that takes in a string and returns nothing, imported from `components/type.tsx`. This is created to pass the `OnSelectFile` function defined in `components/upload.tsx` to the file browser.
+
+### `const FileBrowser: React.FC<FileBrowserProps>`
+File browser component
+
+#### `useState` Properties
+```
+    const [entries, setEntries] = useState<FileEntry[]>([]);
+    const [currentPath, setCurrentPath] = useState<string>('');
+    const [rootPath, setRootPath] = useState<string>('');
+    const [error, setError] = useState<string>('');
+    const [loading, setLoading] = useState<boolean>(false);
+    const [selectedEntries, setSelectedEntries] = useState<Set<string>>(new Set());
+    const [selectAll, setSelectAll] = useState<boolean>(false);
+```
+
+#### `useEffect`
+Defines `fetchRootPath`, which sets `loading` to true and awaits `getServerRootDir`, defined in `API/API_functions`. Sets `rootPath` and `currentPath` to the returned path. Throws an error if any process fails.
+
+#### `useEffect`
+Defines `loadFiles` function, which makes a FETCH request to the `zenodo-jupyterlab/files` API endpoint with `currentPath` encoded. Sets `entries` to the list of entries returned from the API endpoint. Calls `loadFiles` upon changes to `currentPath`.
+
+#### `handleClick(entry: FileEntry)`
+Note: `FileEntry` is a specialized dictionary defined in `components/type.tsx`.\
+If the selected entry was a directory, this function sets `currentPath` to the path of that entry.
+
+#### `handleBreadcrumbClick(path: string)`
+When a breadcrumb (shortbut path links displayed when in nested directories) is clicked, simply sets `currentPath` to that breadcrumb's path.
+
+#### `breadcrumbs = useMemo()`
+Executes on changes to `currentPath` or `rootPath`. Normalized the syntax of the paths, then iterate through each section of `currentPath` after `rootPath`. During this iteration, builds a list of `React.Fragments` which house the breadcrumbs for each nested directory, complete with click logic (`handleBreadcrumbClick`).
+> **Returns:** `breadcrumbItems: list`
+
+#### `handleSelectChange(path: string, isChecked: boolean)`
+Compiles a list of all currently checked files within the browser, held in `selectedEntries`. This function also handles unchecking and removing of entries from this list. Also includes logic that toggles the "Select All" checkbox if the number of entries selected equals the length of the list.
+> **Returns:** `newEntries`
+
+#### `handleSelectFiles`
+Iterates through `selectedEntries` and applies the argument function `onSelectFile` to each's full path. Then sets `selectedEntries` to an empty Set.
+
+#### **Returns**
+Returns the Filebrowser component, comprised of the breadcrumbs, the "Select All" checkbox, the list of files in the current directory (with a folder or file icon, title, size, and date modified), and a "Select" button, which triggers `handleSelectFiles`.
+
+## `components/NavBar.tsx` 
+Component that houses the navigation bar, below the Zenodo title icon in the widget. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
+
+### `interface NavBarProps`
+Defines an `app` parameter of type `@jupyterlab/application/JupyterFrontEnd`. This done is order to use the commands defined in `index.tsx`.
+
+### `NavBar: React.FC<NavBarProps>`
+The navigation bar component.
+
+#### Click Handlers
+All click handlers simply trigger the `app` command corresponding to that button's title. For instance, pressing the "Search" button trigger the `zenodo-jupyterlab: search` command.
+
+#### **Returns**
+Returns the NavBar component, complete with 3 buttons corresponding to the 3 panels available in the widget: "Login", "Search", and "Upload".
+
+## `components/SearchPanel.tsx` 
+This file houses the `SearchWidget` component, which contains all of the search logic and displays the results. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
+
+### `SearchWidget: React.FC`
+Component housing all of the search related features.
+
+#### `useState` Properties
+```
+    const [results, setResults] = useState<any[]>([]);
+    const [searchTerm, setSearchTerm] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [selectedType, setSelectedType] = useState('records');
+    const [lastSearchType, setLastSearchType] = useState('records');
+    const [hasSearched, setHasSearched] = useState(false);
+    const [selectedRecordID, setSelectedRecordID] = useState<number | null>(null);
+    const [recordInfo, setRecordInfo] = useState<any>({});
+    const [recordLoading, setRecordLoading] = useState(false);
+    const [resultsPage, setResultsPage] = useState(1);
+    const [endPage, setEndPage] = useState(false);
+    const [selectedCommunityTitle, setSelectedCommunityTitle] = useState<string | null>(null);
+    const [selectedCommunityID, setSelectedCommunityID] = useState<string | null>(null);
+    const [triggerSearch, setTriggerSearch] = useState(false);
+```
+
+#### `useEffect`
+Upon changes in `triggerSearch` or `selectedCommunityID`, this runs `handleSearch`, passing the `resultsPage`, `selectedType`, and a dictionary of the form `{"communities": selectedCommunityID}` as arguments. Then sets `triggerSearch` to `false`.
+
+#### `handleSearch(page: number, type: string, kwrgs: Record<string, any> = {})`
+This function calls `searchRecords` or `searchCommunities`, both imported from `API/API_functions`, depending on `type`. Then, sets `results` to the returned data. Sets `lastSearchedType` to `type`, as well.
+
+#### `handleCheckboxChange(type: string)`
+Sets `selectedType` to whichever checkbox was selected.
+
+#### `handleRecordRowClick(recordID: number)`
+If the selected record is already selected, `selectedRecordID` is set to `null` and `recordInfo` is set to an empty dictionary. Otherwise, the function makes a call to `recordInformation`, imported from `API/API_functions.tsx` and sets `recordInfo` to what is returned.
+
+#### `handleCommunityClick(communityID: string, communityTitle: string)`
+Runs the following:
+```
+    setSelectedCommunityTitle(communityTitle);
+    setSelectedCommunityID(communityID);
+    setSelectedType('records');
+    setResultsPage(1);
+    setSearchTerm("");
+    setTriggerSearch(true);
+```
+
+#### `handleNextPageClick`
+Increments `resultsPage` and sets `triggerSearch` to true. If the `results` is not greater than 0, then it also sets `endPage` to true.
+
+#### `handleLastPageClick`
+Sets `endPage` to false, then decrements `resultsPage`, and triggers the search.
+
+#### `handleSearchClick`
+Sets `endPage` to false, sets `resultsPage` to 1, and triggers the search.
+
+#### `handleClearCommunity`
+Sets selected community related parameters to `null`, sets `resultsPage` to 1, and triggers the search.
+
+#### `getFileNameFromUrl(url: string)`
+Parses the passed url into a `URL` object. Strips "/content" from the paths. Then returns the last segment of the url.
+> **Returns:** *fileName*
+
+#### `cleanrUrl(url: string)`
+Converts the link attached to the record to a usable download link by stripping the "/content" off of the end and removing "/api" from the path as well.
+> **Returns:** *url*
+
+#### **Returns**
+Always renders a search bar, checkboxes for "records" or "communities" and a "Search" button. The rest is rendered conditionally:
+* If `hasSearched` and `selectedType` is records, it displays a list of the returned records, specifically their title, date published, and resource type.
+> * If a record has been selected, it displays that record's extra information.
+> * If the user is searching within a community, the name is displayed above the list results.
+* If `hasSearched` and `selectedType` is communities, it displays a list of the returned communities, specifically their title and date published.
+* If `hasSearched` but `results.length !> 0`, it displays a screen saying there are no results returned.
+
+The Next and Last page buttons are displayed below the results.
+
+## `components/SideBarPanel.tsx` 
+This is the main component of the extension. This houses every single element. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
+
+### `interface SideBarProps`
+* `app: JupyterFrontEnd`
+* `showLogin: boolean`
+* `showSearch: boolean`
+* `showUpload: boolean`
+
+### `SideBarPanel: React.FC<SideBarProps>`
+Contains all rendered content of the extension.
+
+#### **Returns**
+Returns the Zenodo Title logo (`icons/ZenodoBlueTitle`) and the `NavBar` component, with the `app` passed as an argument. Conditionally renders either `Login`, `SearchWdiget`, or `Upload` depending on the values of the interface props.
+
+## `components/confirmation.tsx` 
+File containing the confirmation page component of the upload component. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
+
+### `interface` (Defined in line with component)
+* `title: string`
+* `resourceType: string`
+* `creators: { name: string; affiliation: string }[]`
+* `doi: string`
+* `filePaths: string[]`
+* `isSandbox: boolean`
+* `description: string`
+* `onEdit: () => void`
+* `onConfirm: () => void`
+
+### `Confirmation: React.FC<Props>`
+Component that is comprised of the users inputted information into the upload page along with a "Confirm" and "Edit" button.
+
+#### **Returns**
+Returns a panel with all of the users inputted information for the record in the upload page, before pressing "Next".
+
+Note:
+* If no `doi` is given, the confirmation page simply displays "automatic".
+* If no `description` is given, the confirmation page displays "none given".
+* The confirmation displays whether or not the deposit is being made to Zenodo or Zenodo Sandbox.
+* The functions triggered by "Edit" and "Confirm" are passed as arguments to this component when rendered in `components/upload.tsx`.
+
+## `components/login.tsx` 
+This file contains the logic and design for the `Login` component of the extension. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
+
+### `Login: React.FC`
+Component housing the login interface of the extension.
+
+#### `useState` Properties
+```
+    const [APIKey, setAPIKey] = useState('');
+    const [outputData, setOutputData] = useState<string | null>(null);
+    const [connectionStatus, setConnectionStatus] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isSandbox, setIsSandbox] = useState(false);
+```
+
+#### `handleLogin: useCallback`
+Function that relies on the setting of `APIKey` and `isSandbox`. Firstly, passes `isSandbox` to the `setEnvVariable` function from `API/API_functions.tsx`, which sets the env var `ZENODO_SANDBOX`. Then, the function uses `setEnvVariable` and `getEnvVariable` and verifies whether or not a key was given in the field. If not, it checks if there is one stored. If yes, then it stores the new key in the environment. Then, it executes `testAPIConnection`, which is defined below.
+
+#### `handleCheckboxChange(event: React.ChangeEvent<HTMLInputElement>)`
+Sets `isSandbox` corresponding to the state of the checkbox.
+
+#### `testAPIConnection`
+Executes `testZenodoConnection` from `API/API_functions.tsx`. Based on the response, sets `connectionStatus` to either a success or failure message.
+
+#### **Returns**
+Returns a field for entering the Zenodo access token, a checkbox indicating whether the user wishes to log in to the standard or sandbox platform, and a "Login" button. Conditionally renders messages indicating the success of storing variables in the environment and the validity of the access token in the chosen platform.
+
+## `components/Upload.tsx` {#upload}
+File containing all of the styling and logic for the `Upload` tab of the extension. Note: all styling is contained within `useStyles`, which is initialized via `react-jss.createUseStyles`.
+
+### `Upload: React.FC`
+Component containing all of the upload-related content.
+
+#### `useState` Properties
+```
+    const [title, setTitle] = useState('');
+    const [resourceType, setResourceType] = useState('');
+    const [creators, setCreators] = useState([{ name: '', affiliation: '' }]);
+    const [doi, setDoi] = useState('');
+    const [isExpanded, setIsExpanded] = useState(false);
+    const [errorMessage, setErrorMessage] = useState('');
+    const [selectedFilePaths, setSelectedFilePaths] = useState<string[]>([]);
+    const [isConfirmationVisible, setIsConfirmationVisible] = useState(false);
+    const [isSandbox, setIsSandbox] = useState(false);
+    const [description, setDescription] = useState('');
+    const [expandedFile, setExpandedFile] = useState<string | null>(null);
+```
+
+#### `useEffect`
+Defines a `fetchSandboxStatus` function that makes a FETCH request to `zenodo-jupyterlab/env` with the encoded `env_var=ZENODO_SANDBOX`. Sets `isSandbox` depending on the returned value. This function is executed on loading on the component.
+
+#### `handleFileClick(filePath: string)`
+Sets `expandedFile` to either `null` or the new `filePath`, depending on whether or not the same was selected that was already expanded.
+
+#### `handleFileRemove(filePath: string)`
+Sets `selectedFilePaths` to the same list excluding the current `filePath`.
+
+#### `handleFileSelect(filePath: string)`
+Appends the selected `filePath` to the existing `selectedFilePaths`.
+
+#### `handleTitleChange(event: React.ChangeEvent<HTMLInputElement>)`
+Sets `title` to the form data.
+
+#### `handleResourceTypeChange(event: React.ChangeEvent<HTMLInputElement>)`
+Sets `resourceType` to the form data.
+
+#### `handleDoiChange(event: React.ChangeEvent<HTMLInputElement>)`
+Sets `doi` to the form data.
+
+#### `handleCreatorChange(index: number, key: 'name' | 'affiliation', value: string)`
+Creates a new Set based on `creators`, then changes the value of an entry based on `index` and `key`. Then, sets this new Set to `creators`.
+
+#### `addCreators`
+Appends a blank creator to the end of `creators`.
+
+#### `handleSubmit`
+Verifies whether or not all required information has been input; if not, generates an error message at the top of the page and exits the function. Otherwise, sets `confirmationVisible` to true.
+
+#### `handleEdit`
+This function hides the confirmation page (passed through to the `Confirmation` component).
+
+#### `handleConfirm`
+Generates a `FormData` object with the input data. Defines an `UploadPayload` object (specific dictionary defined in `components/type.tsx`). Calls `depositUpload`, defined in `API/API_functions`, and passes `payload`.
+
+#### `fileName(filePath: string)`
+> **Returns:** Last segment of `filePath`
+
+#### **Returns**
+If `confirmationVisible`, renders the `Confirmation` component with the following passed as arguments:
+```
+    title={title} 
+    resourceType={resourceType} 
+    creators={creators} 
+    doi={doi} 
+    filePaths={selectedFilePaths} 
+    isSandbox = {isSandbox}
+    description={description}
+    onEdit={handleEdit} 
+    onConfirm={handleConfirm}
+```
+
+If not, the Upload Panel is rendered, which contains fields for every editable part of the deposit, with red asterisks denoting the required fields. The `Filebrowser` is also rendered, having `handleFileSelect` passed as an argument. Further, a list of selected files is conditionally rendered based on whether or not there are currently files selected.

--- a/docs/extensions/zenodo-jupyterlab/implementation/index.md
+++ b/docs/extensions/zenodo-jupyterlab/implementation/index.md
@@ -1,0 +1,44 @@
+# Full Documentation
+This section is dedicated to a full documentation of both the frontend and backend components of the extension. This is intended as a guide for future developers.
+
+## Folder Structure
+Here is the basic folder structure of the major frontend and backend components of this extension. This documentation will be separated by frontend and backend components.
+
+```
+zenodo-jupyterlab-extension/
+├── pyproject.toml
+├── requirements.txt
+├── setup.py
+├── src/                     #frontend
+│   ├── API/
+│   │   ├── API_functions.tsx
+│   │   ├── handler.tsx
+│   ├── components/
+│   │   ├── NavBar.tsx
+│   │   ├── SearchPanel.tsx
+│   │   ├── SideBarPanel.tsx
+│   │   └── login.tsx
+│   ├── icons/
+│   │   ├── ZenodoBlueTitle.tsx
+│   │   ├── z_icon.svg
+│   │   ├── zenodo-black.svg
+│   │   └── zenodo-blue.svg
+│   ├── index.tsx
+│   └── svg.d.tsx
+├── zenodo_jupyterlab/ 
+│   ├── __init__.py
+│   ├── _version.py
+│   ├── labextension/
+│   │   ├── build_log.json
+│   │   ├── package.json
+│   │   └── static/
+│   └── server/         #backend
+│       ├── __init__.py
+│       ├── extension.py
+│       ├── handlers.py
+│       ├── search.py
+│       ├── testConnection.py
+│       └── tests/
+│           ├── test_search.py
+│           └── test_testConnection.py
+```

--- a/docs/extensions/zenodo-jupyterlab/index.md
+++ b/docs/extensions/zenodo-jupyterlab/index.md
@@ -1,0 +1,14 @@
+# Zenodo JupyterLab Extension
+
+[![Build and install extension](https://github.com/vre-hub/zenodo-jupyterlab-extension/actions/workflows/build.yaml/badge.svg)](https://github.com/vre-hub/zenodo-jupyterlab-extension/actions/workflows/build.yaml)
+
+This project integrates [Zenodo](https://zenodo.org) into a JupyterLab environment.
+Check [here](https://github.com/vre-hub/zenodo-jupyterlab-extension) the source code of the extension.
+
+# Requirements
+* `jupyterlab >4, <5`
+* `notebook <7`
+* [eOSSR](https://gitlab.com/escape-ossr/eossr)
+
+# Motivation
+This project is being developed as a part of the Virtual Research Environment ([VRE](https://github.com/vre-hub)) initiative, created as a part of the [ESCAPE Collaboration](https://projectescape.eu/). The end goal of the VRE is to develop a Hub which aggregates software and infrastructure to create an end-to-end analysis facility for physicists.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -123,6 +123,11 @@ const config = {
                 sidebarId: 'ReanaJupyterlab',
                 label: 'Reana Jupyterlab',
               },
+              {
+                type: 'docSidebar',
+                sidebarId: 'ZenodoJupyterlab',
+                label: 'Zenodo Jupyterlab',
+              },
             ],
           },
         ],

--- a/sidebars.js
+++ b/sidebars.js
@@ -91,6 +91,37 @@ const sidebars = {
       ],
     },
   ],
+
+  ZenodoJupyterlab: [
+    {
+      type: 'doc',
+      label: 'Home',
+      id: 'extensions/zenodo-jupyterlab/index',
+    },
+    {
+      type: 'doc',
+      label: 'Installation',
+      id: 'extensions/zenodo-jupyterlab/install',
+    },
+    {
+      type: 'doc',
+      label: 'Extension usage',
+      id: 'extensions/zenodo-jupyterlab/extension-usage',
+    },
+    {
+      type: 'category',
+      label: 'Implementation',
+      link: {
+        type: 'doc',
+        id: 'extensions/zenodo-jupyterlab/implementation/index',
+      },
+      items: [
+        'extensions/zenodo-jupyterlab/frontend',
+        'extensions/zenodo-jupyterlab/backend',
+      ],
+    },
+  ],
+
 };
 
 export default sidebars;

--- a/sidebars.js
+++ b/sidebars.js
@@ -116,8 +116,8 @@ const sidebars = {
         id: 'extensions/zenodo-jupyterlab/implementation/index',
       },
       items: [
-        'extensions/zenodo-jupyterlab/frontend',
-        'extensions/zenodo-jupyterlab/backend',
+        'extensions/zenodo-jupyterlab/implementation/frontend',
+        'extensions/zenodo-jupyterlab/implementation/backend',
       ],
     },
   ],


### PR DESCRIPTION
@mrzengel Just moving documentation so that we have all the extensions on the same place. 
Fell free to have a look/comment.

Also updates CI so that PRs are `yarn build` via the `test_build` action, but doest NOT deploy