### PR TITLE
Remove edit link from pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,8 +44,8 @@ const config = {
           // routeBasePath: '/',
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          // editUrl:
-          //   'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+          editUrl:
+            'https://github.com/vre-hub/vre-hub.github.io/tree/main',
         },
         // blog: {
         //   showReadingTime: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,8 +44,8 @@ const config = {
           // routeBasePath: '/',
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+          // editUrl:
+          //   'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
         },
         // blog: {
         //   showReadingTime: true,


### PR DESCRIPTION
Removed the editUrl feature from config: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#custom_edit_url